### PR TITLE
Fix: Enable experimental decorators in TypeScript config

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,8 @@
     "resolveJsonModule": true,
     "declaration": true,
     "sourceMap": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
     // Consider enabling these gradually for better type safety
     "noImplicitAny": false, // Try to enable this first
     "strictNullChecks": false, // Enable this second


### PR DESCRIPTION
## Summary
- Enable experimentalDecorators in tsconfig.json
- Enable emitDecoratorMetadata in tsconfig.json

This PR fixes the TypeScript decorator error in the ContentController.ts file.

🤖 Generated with [Claude Code](https://claude.ai/code)